### PR TITLE
Update name, repository url, homepage, and bugs url for release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "yaml-ast-parser-custom-tags",
+  "name": "yaml-language-server-parser",
   "version": "0.0.43",
   "main": "dist/src/index.js",
   "scripts": {
@@ -11,17 +11,17 @@
   "typings": "dist/src/index.d.ts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/jpinkney/yaml-ast-parser.git"
+    "url": "https://github.com/redhat-developer/yaml-ast-parser.git"
   },
   "keywords": [
     "raml",
     "ast",
     "yaml"
   ],
-  "homepage": "https://github.com/mulesoft-labs/yaml-ast-parser",
+  "homepage": "https://github.com/redhat-developer/yaml-ast-parser",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/mulesoft-labs/yaml-ast-parser/issues"
+    "url": "https://github.com/redhat-developer/yaml-ast-parser/issues"
   },
   "devDependencies": {
     "@types/chai": "4.2.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yaml-language-server-parser",
-  "version": "0.0.43",
+  "version": "0.1.0",
   "main": "dist/src/index.js",
   "scripts": {
     "build": "rimraf dist && tsc",


### PR DESCRIPTION
This PR changes the name, repository url, homepage, and bugs sections of the package.json to prep the project for release. I've changed the name to something that makes a bit more sense considering we're going to be maintaining this project for the yaml language server.

Alternatively, we could change the name to be scoped as something like `@redhat-developer/yaml-ast-parser`

Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>