### PR TITLE
Add release github action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,47 @@
+# This is a basic workflow to help you get started with Actions
+
+name: Release to NPM
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  create:
+    tags:
+      - '*'
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - uses: actions/checkout@v2
+
+      # Set up Node
+    - name: Use Node 12
+      uses: actions/setup-node@v1
+      with:
+        node-version: 12
+
+      # Run install dependencies
+    - name: Install dependencies
+      run: npm install
+
+      # Build extension
+    - name: Run build
+      run: npm run build
+
+      # Run tests
+    - name: Run Test
+      run: npm run test
+
+      # Publish to npm
+    - run: npm publish --access public
+      env:
+        NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}


### PR DESCRIPTION
This PR adds a github action for releasing when a tag is created. I'm not entirely sure how to test this. I've mostly just copied everything from the CI.yaml file in the repo, made it work when tags are created and added npm publish

Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>