### PR TITLE
fix: array newLine ending with no indent

### DIFF
--- a/src/loader.ts
+++ b/src/loader.ts
@@ -1135,8 +1135,13 @@ function readBlockSequence(state:State, nodeIndent) {
     state.tag = _tag;
     state.anchor = _anchor;
     state.kind = 'sequence';
+    var endPosition = state.position;
+    if(state.lineIndent < nodeIndent && state.result && state.result.endPosition){
+      //use last node endPosition - with no empty lines
+        endPosition = state.result.endPosition;
+    }
     state.result = _result;
-    _result.endPosition=state.position;
+    _result.endPosition=endPosition;
     return true;
   }
   return false;


### PR DESCRIPTION
## Describe the bug
Copied from https://github.com/p-spacek/yaml-language-server/issues/1

This 'bug' can be observe by code completion in this scenario:
Array:

https://user-images.githubusercontent.com/38421337/103294682-9d020280-49f2-11eb-871f-18bc59a44aab.mov

Object works fine:

https://user-images.githubusercontent.com/38421337/103294515-4bf20e80-49f2-11eb-80ba-be5901e660f7.mov

Bug is in dependent project yaml-ast-parser, when array node ending with empty lines with no indent
Similar example with object instead of array works fine.

## Expected Behavior
This is expected behavior - fixed in yaml-ast-parser

https://user-images.githubusercontent.com/38421337/103294707-aa1ef180-49f2-11eb-8f1e-382b6977e33e.mov


## Current Behavior
see description

## Steps to Reproduce
see description

## Environment
- [ ] Windows
- [x] Mac
- [ ] Linux
- [x] probably on every environment 

## How PR is tested
Unit test is written in  yaml-language-server repository
https://github.com/redhat-developer/yaml-language-server/pull/384